### PR TITLE
feat(extras): ghostty themes

### DIFF
--- a/extras/ghostty/README.md
+++ b/extras/ghostty/README.md
@@ -1,0 +1,16 @@
+## Ghostty Jellybeans Theme
+To use this theme:
+1. Navigate to your Ghostty config directory (usually $HOME/.config/ghostty)
+2. Inside the Ghostty config directory, create a directory named `themes` if it does not exist already.  
+Save the colorscheme file - `jellybeans` (dark) or `jellybeans-light` (light) in this directory  
+You can choose either file based on your preference.
+3. Edit the Ghostty config file, (usually $HOME/.config/ghostty/config) and append one of the following lines:  
+- For the dark theme:
+```
+theme = jellybeans
+```
+- For the light theme:
+```
+theme = jellybeans-light
+```
+4. Reload your Ghostty config

--- a/extras/ghostty/jellybeans
+++ b/extras/ghostty/jellybeans
@@ -1,0 +1,31 @@
+# name = "jellybeans-dark"
+# author = "A. Fox"
+
+palette = 0=#151515
+palette = 1=#cf6a4c
+palette = 2=#99ad6a
+palette = 3=#fad07a
+palette = 4=#8197bf
+palette = 5=#c6b6ee
+palette = 6=#668799
+palette = 7=#e8e8d3
+palette = 8=#888888
+palette = 9=#902020
+palette = 10=#70b950
+palette = 11=#ffb964
+palette = 12=#8fbfdc
+palette = 13=#700089
+palette = 14=#8fbfdc
+palette = 15=#f0f0f0
+palette = 16=#cf6a4c
+palette = 17=#d8ad4c
+palette = 18=#1c1c1c
+palette = 19=#303030
+palette = 20=#636363
+palette = 21=#c7c7c7
+
+background = 151515
+foreground = e8e8d3
+cursor-color = b0d0f0
+selection-background = 404040
+selection-foreground = e8e8d3

--- a/extras/ghostty/jellybeans-light
+++ b/extras/ghostty/jellybeans-light
@@ -1,0 +1,31 @@
+# name = "jellybeans-light"
+# author = "A. Fox"
+
+palette = 0=#f5f5f5
+palette = 1=#954d3b
+palette = 2=#386014
+palette = 3=#876820
+palette = 4=#234291
+palette = 5=#6a4abd
+palette = 6=#2B5B77
+palette = 7=#444444
+palette = 8=#787878
+palette = 9=#a02020
+palette = 10=#457039
+palette = 11=#a66a10
+palette = 12=#2952a3
+palette = 13=#540063
+palette = 14=#3a596a
+palette = 15=#262626
+palette = 16=#904070
+palette = 17=#556633
+palette = 18=#e0dcd7
+palette = 19=#595959
+palette = 20=#7a8490
+palette = 21=#f8f8f8
+
+background = fdf6ec
+foreground = 262626
+cursor-color = 262626
+selection-background = 787878
+selection-foreground = fdf6ec


### PR DESCRIPTION
Adds theme files for Ghostty users who want to apply the jellybeans.nvim palette to their terminal emulator.