### PR TITLE
docs(README): update link to tokyonight repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ require('lualine').setup {
 ## 💕 Inspirations
 
 - [jellybeans.vim](https://github.com/nanotech/jellybeans.vim)
-- [tokyonight.nvim](https://gitub.com/folke/tokyonight.nvim) by [Folke](https://githubcom/folke)
+- [tokyonight.nvim](https://github.com/folke/tokyonight.nvim) by [Folke](https://githubcom/folke)
 - [jellybeans-nvim](https://github.com/metalelf0/jellybeans-nvim) by [metalelf0](https://github.com/metalelf0)
 - [jbeans](https://github.com/scajanus/jbeans) by [scajanus](https://github.com/scajanus)
 


### PR DESCRIPTION
Was scrolling through the README and discovered a broken link to TokyoNight