### PR TITLE
Add extras/ghostty/jellybean-nvim theme

### DIFF
--- a/extras/ghostty/jellybeans-muted
+++ b/extras/ghostty/jellybeans-muted
@@ -1,0 +1,31 @@
+# name = "jellybeans-muted"
+# author = "A. Fox"
+
+palette = 0=#101010
+palette = 1=#cc4d4d
+palette = 2=#909c6e
+palette = 3=#e8c88c
+palette = 4=#7a8aa6
+palette = 5=#b8aed3
+palette = 6=#617b87
+palette = 7=#dad6c8
+palette = 8=#7a7a7a
+palette = 9=#7e2e23
+palette = 10=#6aa84c
+palette = 11=#d8a16c
+palette = 12=#83adc3
+palette = 13=#5c1e68
+palette = 14=#83adc3
+palette = 15=#e9e5dc
+palette = 16=#cc4d4d
+palette = 17=#d9a45a
+palette = 18=#1e1e1c
+palette = 19=#3c3936
+palette = 20=#6f6f6c
+palette = 21=#bebebe
+
+background = #101010
+foreground = #dad6c8
+cursor-color = #a6c3d9
+selection-background = #3c3b38
+selection-foreground = #dad6c8


### PR DESCRIPTION
Hi,

I created a `jellybeans-muted` theme for ghostty.

I only used colors from the neovim [jellybeans_muted.lua](https://github.com/WTFox/jellybeans.nvim/blob/main/lua/jellybeans/palettes/jellybeans_muted.lua) palette file.

I noticed that in the default [jellybeans](https://github.com/WTFox/jellybeans.nvim/blob/main/extras/ghostty/jellybeans) ghostty theme you used five colors which do not exist in the neovim [jellybeans.lua](https://github.com/WTFox/jellybeans.nvim/blob/main/lua/jellybeans/palettes/jellybeans.lua) palette file, namely these (one color repeats):

```sh
palette = 1=#cf6a4c
...
palette = 11=#ffb964
...
palette = 16=#cf6a4c
palette = 17=#d8ad4c
...
palette = 19=#303030
palette = 20=#636363
```

so I tried to match those colors as best as I could for the muted version.

Please let me know what you think.