### PR TITLE
feat!: replace `style` and `palette` options with `background` config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,126 @@
+name: Bug Report
+description: File a bug report related to jellybeans.nvim
+title: "[Bug]: "
+labels: ["bug", "triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        Please complete the following information to help us address the issue quickly.
+
+  - type: checkboxes
+    id: pre-checks
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following before submitting your bug report
+      options:
+        - label: I have updated jellybeans.nvim to the latest version
+          required: true
+        - label: I have searched existing issues to avoid creating duplicates
+          required: true
+        - label: I have verified this issue is related to jellybeans.nvim and not another plugin
+          required: true
+
+  - type: input
+    id: nvim-version
+    attributes:
+      label: Neovim Version
+      description: "What version of Neovim are you using? Run `:version` to find out."
+      placeholder: "Example: NVIM v0.9.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: terminal
+    attributes:
+      label: Terminal Emulator
+      description: Which terminal emulator are you using?
+      options:
+        - iTerm2
+        - Alacritty
+        - Kitty
+        - Windows Terminal
+        - Wezterm
+        - Tmux
+        - Other (please specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Which operating system are you using?
+      placeholder: "Example: macOS 13.5, Ubuntu 22.04, Windows 11"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: term-colors
+    attributes:
+      label: Terminal Colors
+      description: "Is `termguicolors` enabled? Run `:set termguicolors?` to find out."
+      options:
+        - "Yes"
+        - "No"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is
+      placeholder: When using the jellybeans colorscheme, the cursor line highlight doesn't show up correctly...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen
+      placeholder: The cursor line should be highlighted with a subtle gray color...
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem
+      placeholder: Drag and drop screenshots here
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal configuration example
+      description: Please provide a minimal configuration that reproduces the issue
+      placeholder: |
+        ```lua
+        -- Minimal init.lua example to reproduce the issue
+        vim.o.termguicolors = true
+        
+        require('jellybeans').setup({
+          -- Your configuration options here
+        })
+        
+        vim.cmd.colorscheme('jellybeans')
+        ```
+      render: lua
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here
+      placeholder: Any additional information that might be helpful...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/anthonyfox/jellybeans.nvim/discussions
+    about: Please ask and answer questions here
+  - name: Documentation
+    url: https://github.com/anthonyfox/jellybeans.nvim#readme
+    about: Make sure you've read the documentation before submitting an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,90 @@
+name: Feature Request
+description: Suggest an idea or enhancement for jellybeans.nvim
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature or enhancement for jellybeans.nvim!
+        Please complete the following information to help us understand your request.
+
+  - type: checkboxes
+    id: pre-checks
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following before submitting your feature request
+      options:
+        - label: I have searched existing issues to avoid creating duplicates
+          required: true
+        - label: I have checked the documentation to confirm this feature doesn't already exist
+          required: true
+        - label: This feature is related to jellybeans.nvim and not another plugin
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen
+      placeholder: I would like jellybeans.nvim to support [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered
+      placeholder: I've tried using [...] as a workaround, but it doesn't fully solve the problem because [...]
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or mockups
+      description: If applicable, add screenshots or mockups to help explain your feature request
+      placeholder: Drag and drop images here or describe the visual appearance you're looking for
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration example
+      description: If possible, provide an example of how you envision configuring this feature
+      placeholder: |
+        ```lua
+        -- Example configuration for the requested feature
+        require('jellybeans').setup({
+          -- Your proposed configuration options
+          new_feature = {
+            enabled = true,
+            option1 = "value1",
+            option2 = "#ff5500"
+          }
+        })
+        ```
+      render: lua
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the feature request here
+      placeholder: Any additional information that might be helpful...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/theme_issue.yml
+++ b/.github/ISSUE_TEMPLATE/theme_issue.yml
@@ -1,0 +1,139 @@
+name: Theme Issue
+description: Report an issue with the jellybeans.nvim colorscheme appearance
+title: "[Theme]: "
+labels: ["theme", "appearance"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report an issue with the jellybeans.nvim colorscheme!
+        Please complete the following information to help us address the issue quickly.
+
+  - type: checkboxes
+    id: pre-checks
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following before submitting
+      options:
+        - label: I have updated jellybeans.nvim to the latest version
+          required: true
+        - label: I have searched existing issues to avoid creating duplicates
+          required: true
+        - label: I have verified `termguicolors` is enabled in my Neovim configuration
+          required: true
+
+  - type: dropdown
+    id: theme-variant
+    attributes:
+      label: Theme Variant
+      description: Which theme variant are you using?
+      options:
+        - jellybeans (default)
+        - jellybeans-light
+        - jellybeans-muted
+        - jellybeans-muted-light
+        - Other (please specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: nvim-version
+    attributes:
+      label: Neovim Version
+      description: "What version of Neovim are you using? Run `:version` to find out."
+      placeholder: "Example: NVIM v0.9.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: terminal
+    attributes:
+      label: Terminal Emulator
+      description: Which terminal emulator are you using?
+      options:
+        - iTerm2
+        - Alacritty
+        - Kitty
+        - Windows Terminal
+        - Wezterm
+        - Tmux
+        - Other (please specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Which operating system are you using?
+      placeholder: "Example: macOS 13.5, Ubuntu 22.04, Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of what the theme issue is
+      placeholder: The comments in JavaScript files are too dark and hard to read...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected appearance
+      description: A clear and concise description of how you expect it to look
+      placeholder: The comments should be a lighter shade of gray to improve readability...
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots to help explain your problem
+      placeholder: Drag and drop screenshots here showing the current appearance
+    validations:
+      required: true
+
+  - type: textarea
+    id: syntax-elements
+    attributes:
+      label: Affected syntax elements
+      description: If known, which syntax elements or highlight groups are affected?
+      placeholder: |
+        - Comment
+        - Function
+        - Keyword
+        - If not known, describe what type of code or content is showing the issue
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal configuration example
+      description: Please provide your jellybeans.nvim configuration
+      placeholder: |
+        ```lua
+        -- How you're setting up jellybeans.nvim
+        require('jellybeans').setup({
+          -- Your configuration options here
+        })
+        
+        vim.cmd.colorscheme('jellybeans')
+        ```
+      render: lua
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here
+      placeholder: Any additional information that might be helpful...
+    validations:
+      required: false

--- a/.lazy.lua
+++ b/.lazy.lua
@@ -1,11 +1,11 @@
-if true then
-  return {}
-end
-
 local M = {
   module = "jellybeans",
-  palette = "jellybeans_muted",
-  style = "dark",
+  -- palette = "jellybeans_muted",
+  -- style = "dark",
+  background = {
+    dark = "jellybeans_muted",
+    light = "jellybeans_muted_light",
+  },
   opts = {
     flat_ui = false,
     plugins = {
@@ -14,11 +14,12 @@ local M = {
   },
   globals = { vim = vim },
   cache = {}, ---@type table<string, boolean>
+  colorscheme = "jellybeans",
 }
 
 function M.reset()
   require("jellybeans.util").cache.clear()
-  local colors = require("jellybeans.palettes").get_palette("jellybeans", { style = "dark" })
+  local colors = require("jellybeans.palettes").get_palette("jellybeans", {})
   M.globals.colors = colors
   M.globals.c = colors
 end

--- a/.lazy.lua
+++ b/.lazy.lua
@@ -1,7 +1,5 @@
 local M = {
   module = "jellybeans",
-  -- palette = "jellybeans_muted",
-  -- style = "dark",
   background = {
     dark = "jellybeans_muted",
     light = "jellybeans_muted_light",

--- a/.lazy.lua
+++ b/.lazy.lua
@@ -1,8 +1,13 @@
+if true then
+  return {}
+end
+
 local M = {
   module = "jellybeans",
-  colorscheme = "jellybeans",
+  palette = "jellybeans_muted",
+  style = "dark",
   opts = {
-    flat_ui = true,
+    flat_ui = false,
     plugins = {
       all = true,
     },

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 A port of the jellybeans colorscheme for Neovim, written in Lua. Comes with multiple palettes.
 
-_Vibrant Dark (Default) (palette = nil or "jellybeans")_
+\_Vibrant Dark (Default)
 ![Vibrant Dark](./images/default-vibrant.png)
 
-_Vibrant Light (palette = "jellybeans_light")_
+_Vibrant Light (`jellybeans_light`)_
 ![Vibrant Light](./images/default-vibrant-light.png)
 
-_Muted Dark (palette = "jellybeans_muted")_
+_Muted Dark (`jellybeans_muted`)_
 ![Muted Dark](./images/muted.png)
 
-_Muted Light (palette = "jellybeans_muted_light")_
+_Muted Light (`jellybeans_muted_light`)_
 ![Muted Light](./images/muted-light.png)
 
 ## ✨ Features
@@ -55,11 +55,13 @@ Jellybeans ships with the following defaults
 
 ```lua
 {
-  style = "dark", -- "dark" or "light"
   transparent = false,
   italics = true,
   flat_ui = true, -- toggles "flat UI" for pickers
-  palette = nil, -- specify a palette variant: nil (default/"vibrant") or "jellybeans_muted"
+  background = {
+    dark = "jellybeans", -- default dark palette
+    light = "jellybeans_light", -- default light palette
+  },
   plugins = {
     all = false,
     auto = true, -- will read lazy.nvim and apply the colors for plugins that are installed
@@ -70,6 +72,8 @@ Jellybeans ships with the following defaults
   end,
 }
 ```
+
+> **Deprecated**: `style` and `palette` are no longer used. Instead, use the `background` table to set the default palette for dark and light backgrounds. This allows for more flexibility for future palettes and for your personal preferences.
 
 ### Available Palettes
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A port of the jellybeans colorscheme for Neovim, written in Lua. Comes with multiple palettes.
 
-\_Vibrant Dark (Default)
+_Vibrant Dark (Default)_
 ![Vibrant Dark](./images/default-vibrant.png)
 
 _Vibrant Light (`jellybeans_light`)_

--- a/colors/jellybeans-default.lua
+++ b/colors/jellybeans-default.lua
@@ -1,0 +1,1 @@
+require("jellybeans").load("jellybeans")

--- a/colors/jellybeans-light.lua
+++ b/colors/jellybeans-light.lua
@@ -1,1 +1,2 @@
-require("jellybeans").load({ style = "light" })
+require("jellybeans").load("jellybeans_light")
+

--- a/colors/jellybeans-muted-light.lua
+++ b/colors/jellybeans-muted-light.lua
@@ -1,1 +1,2 @@
-require("jellybeans").load({ palette = "jellybeans_muted", style = "light" })
+require("jellybeans").load("jellybeans_muted_light")
+

--- a/colors/jellybeans-muted.lua
+++ b/colors/jellybeans-muted.lua
@@ -1,1 +1,2 @@
-require("jellybeans").load({ palette = "jellybeans_muted" })
+require("jellybeans").load("jellybeans_muted")
+

--- a/colors/jellybeans.lua
+++ b/colors/jellybeans.lua
@@ -1,2 +1,1 @@
--- This is just a loader file
 require("jellybeans").load()

--- a/lua/jellybeans/config.lua
+++ b/lua/jellybeans/config.lua
@@ -1,8 +1,10 @@
 local M = {}
 
----@class jellybeans.Background
----@field dark string
----@field light string
+---@alias palette_name "jellybeans" | "jellybeans_light" | "jellybeans_muted" | "jellybeans_muted_light"
+
+---@class jellybeans.Config.Background
+---@field dark palette_name
+---@field light palette_name
 
 ---@class jellybeans.Config
 ---@field transparent? boolean
@@ -10,15 +12,15 @@ local M = {}
 ---@field flat_ui? boolean
 ---@field on_highlights? fun(highlights: jellybeans.Highlights, colors: ColorScheme)
 ---@field on_colors? fun(colors: ColorScheme)
----@field background? jellybeans.Background
+---@field background? jellybeans.Config.Background
 M.defaults = {
+  transparent = false,
+  italics = true,
+  flat_ui = true,
   background = {
     dark = "jellybeans_muted",
     light = "jellybeans_muted_light",
   },
-  transparent = false,
-  italics = true,
-  flat_ui = true,
   plugins = {
     all = false,
     auto = true,
@@ -29,6 +31,20 @@ M.defaults = {
 
 ---@param opts? jellybeans.Config
 function M.setup(opts)
+  if opts.style ~= nil then
+    vim.notify_once(
+      "[jellybeans.nvim] opts.style is deprecated, please use opts.background instead. Refer to README for usage.",
+      vim.log.levels.WARN
+    )
+  end
+
+  if opts.palette ~= nil then
+    vim.notify_once(
+      "[jellybeans.nvim] opts.palette is deprecated, please use opts.background instead. Refer to README for usage.",
+      vim.log.levels.WARN
+    )
+  end
+
   M.opts = M.extend(opts)
 end
 

--- a/lua/jellybeans/config.lua
+++ b/lua/jellybeans/config.lua
@@ -1,19 +1,24 @@
 local M = {}
 
+---@class jellybeans.Background
+---@field dark string
+---@field light string
+
 ---@class jellybeans.Config
----@field style? "dark"|"light"
 ---@field transparent? boolean
 ---@field italics? boolean
 ---@field flat_ui? boolean
----@field palette? string
 ---@field on_highlights? fun(highlights: jellybeans.Highlights, colors: ColorScheme)
 ---@field on_colors? fun(colors: ColorScheme)
+---@field background? jellybeans.Background
 M.defaults = {
-  style = "dark",
+  background = {
+    dark = "jellybeans_muted",
+    light = "jellybeans_muted_light",
+  },
   transparent = false,
   italics = true,
   flat_ui = true,
-  palette = nil,
   plugins = {
     all = false,
     auto = true,

--- a/lua/jellybeans/groups/init.lua
+++ b/lua/jellybeans/groups/init.lua
@@ -36,6 +36,7 @@ function M.setup(colors, opts)
     syntax = true,
     semantic_tokens = true,
     treesitter = true,
+    terminal = true,
   }
   if opts.plugins.all then
     for _, group in pairs(M.plugins) do

--- a/lua/jellybeans/groups/terminal.lua
+++ b/lua/jellybeans/groups/terminal.lua
@@ -1,0 +1,34 @@
+local M = {}
+
+function M.get(c, opts)
+  -- Empty table for highlight groups
+  local highlights = {}
+  
+  -- Set up terminal colors directly using vim.g
+  local terminal_colors = {
+    [0] = c.total_black,     -- Black
+    [1] = c.old_brick,       -- Red
+    [2] = c.highland,        -- Green
+    [3] = c.brandy,          -- Yellow
+    [4] = c.ship_cove,       -- Blue
+    [5] = c.wewak,           -- Magenta
+    [6] = c.morning_glory,   -- Cyan
+    [7] = c.silver,          -- White
+    [8] = c.grey,            -- Bright Black
+    [9] = c.raw_sienna,      -- Bright Red
+    [10] = c.mantis,         -- Bright Green
+    [11] = c.goldenrod,      -- Bright Yellow
+    [12] = c.perano,         -- Bright Blue
+    [13] = c.biloba_flower,  -- Bright Magenta
+    [14] = c.morning_glory,  -- Bright Cyan
+    [15] = c.total_white,    -- Bright White
+  }
+  
+  -- Return an empty table for highlight groups
+  -- The terminal colors will be applied in a separate post-processing step
+  return {
+    _terminal_colors = terminal_colors, -- Store colors for later use
+  }
+end
+
+return M

--- a/lua/jellybeans/groups/terminal.lua
+++ b/lua/jellybeans/groups/terminal.lua
@@ -1,33 +1,27 @@
 local M = {}
 
 function M.get(c, opts)
-  -- Empty table for highlight groups
-  local highlights = {}
-  
-  -- Set up terminal colors directly using vim.g
   local terminal_colors = {
-    [0] = c.total_black,     -- Black
-    [1] = c.old_brick,       -- Red
-    [2] = c.highland,        -- Green
-    [3] = c.brandy,          -- Yellow
-    [4] = c.ship_cove,       -- Blue
-    [5] = c.wewak,           -- Magenta
-    [6] = c.morning_glory,   -- Cyan
-    [7] = c.silver,          -- White
-    [8] = c.grey,            -- Bright Black
-    [9] = c.raw_sienna,      -- Bright Red
-    [10] = c.mantis,         -- Bright Green
-    [11] = c.goldenrod,      -- Bright Yellow
-    [12] = c.perano,         -- Bright Blue
-    [13] = c.biloba_flower,  -- Bright Magenta
-    [14] = c.morning_glory,  -- Bright Cyan
-    [15] = c.total_white,    -- Bright White
+    [0] = c.total_black,
+    [1] = c.old_brick,
+    [2] = c.highland,
+    [3] = c.brandy,
+    [4] = c.ship_cove,
+    [5] = c.wewak,
+    [6] = c.morning_glory,
+    [7] = c.silver,
+    [8] = c.grey,
+    [9] = c.raw_sienna,
+    [10] = c.mantis,
+    [11] = c.goldenrod,
+    [12] = c.perano,
+    [13] = c.biloba_flower,
+    [14] = c.morning_glory,
+    [15] = c.total_white,
   }
-  
-  -- Return an empty table for highlight groups
-  -- The terminal colors will be applied in a separate post-processing step
+
   return {
-    _terminal_colors = terminal_colors, -- Store colors for later use
+    _terminal_colors = terminal_colors,
   }
 end
 

--- a/lua/jellybeans/highlights.lua
+++ b/lua/jellybeans/highlights.lua
@@ -2,6 +2,12 @@ local M = {}
 
 ---@param opts? jellybeans.Config
 function M.setup(opts, palette_name_override)
+  if vim.g.colors_name then
+    vim.cmd("hi clear")
+  end
+
+  vim.opt.termguicolors = true
+
   local bg = vim.o.background
   local palette_name = palette_name_override and palette_name_override or (opts and opts.background[bg]) or "jellybeans"
   local p = require("jellybeans.palettes").get_palette(palette_name, opts)

--- a/lua/jellybeans/highlights.lua
+++ b/lua/jellybeans/highlights.lua
@@ -2,40 +2,27 @@ local M = {}
 
 ---@param opts? jellybeans.Config
 function M.setup(opts)
-  if not opts then
-    opts = require("jellybeans.config").opts
-  end
+  local bg = vim.o.background
+  dd("highlights.setup", bg, vim.g.colors_name)
+  local palette_name = opts.background[bg]
+  vim.g.colors_name = palette_name
 
-  local current_scheme = vim.g.colors_name
+  local p = require("jellybeans.palettes").get_palette(palette_name, opts)
 
-  if vim.g.colors_name then
-    vim.cmd("hi clear")
-  end
-
-  vim.opt.termguicolors = true
-
-  vim.o.background = opts.style == "light" and "light" or "dark"
-  vim.g.colors_name = current_scheme or "jellybeans"
-
-  local style = opts.style or (vim.o.background == "light" and "light" or "dark")
-  local palette_name = opts.palette or "jellybeans"
-  local colors = require("jellybeans.palettes").get_palette(palette_name, { 
-    style = style,
-    on_colors = opts.on_colors
-  })
-  if not colors then
-    vim.notify("Failed to load jellybeans colorscheme", vim.log.levels.ERROR)
-    return
-  end
-
-  local groups = require("jellybeans.groups").setup(colors, opts)
+  local groups = require("jellybeans.groups").setup(p.palette, opts)
 
   for group, hl in pairs(groups) do
     hl = type(hl) == "string" and { link = hl } or hl
     vim.api.nvim_set_hl(0, group, hl)
   end
 
-  return colors, groups, opts
+  local has_lualine, lualine = pcall(require, "lualine")
+  if has_lualine then
+    vim.notify("refreshing lualine")
+    lualine.refresh()
+  end
+
+  return p.palette, groups, opts
 end
 
 return M

--- a/lua/jellybeans/highlights.lua
+++ b/lua/jellybeans/highlights.lua
@@ -1,9 +1,9 @@
 local M = {}
 
 ---@param opts? jellybeans.Config
-function M.setup(opts)
+function M.setup(opts, palette_name_override)
   local bg = vim.o.background
-  local palette_name = opts and opts.background[bg] or "jellybeans"
+  local palette_name = palette_name_override and palette_name_override or (opts and opts.background[bg]) or "jellybeans"
   local p = require("jellybeans.palettes").get_palette(palette_name, opts)
 
   local groups = require("jellybeans.groups").setup(p.palette, opts)

--- a/lua/jellybeans/highlights.lua
+++ b/lua/jellybeans/highlights.lua
@@ -13,9 +13,21 @@ function M.setup(opts, palette_name_override)
   local p = require("jellybeans.palettes").get_palette(palette_name, opts)
 
   local groups = require("jellybeans.groups").setup(p.palette, opts)
+
+  local terminal_colors = nil
   for group, hl in pairs(groups) do
-    hl = type(hl) == "string" and { link = hl } or hl
-    vim.api.nvim_set_hl(0, group, hl)
+    if group == "_terminal_colors" then
+      terminal_colors = hl
+    else
+      hl = type(hl) == "string" and { link = hl } or hl
+      vim.api.nvim_set_hl(0, group, hl)
+    end
+  end
+
+  if terminal_colors then
+    for i = 0, 15 do
+      vim.g["terminal_color_" .. i] = terminal_colors[i]
+    end
   end
 
   local has_lualine, lualine = pcall(require, "lualine")

--- a/lua/jellybeans/highlights.lua
+++ b/lua/jellybeans/highlights.lua
@@ -3,14 +3,10 @@ local M = {}
 ---@param opts? jellybeans.Config
 function M.setup(opts)
   local bg = vim.o.background
-  dd("highlights.setup", bg, vim.g.colors_name)
-  local palette_name = opts.background[bg]
-  vim.g.colors_name = palette_name
-
+  local palette_name = opts and opts.background[bg] or "jellybeans"
   local p = require("jellybeans.palettes").get_palette(palette_name, opts)
 
   local groups = require("jellybeans.groups").setup(p.palette, opts)
-
   for group, hl in pairs(groups) do
     hl = type(hl) == "string" and { link = hl } or hl
     vim.api.nvim_set_hl(0, group, hl)
@@ -18,7 +14,6 @@ function M.setup(opts)
 
   local has_lualine, lualine = pcall(require, "lualine")
   if has_lualine then
-    vim.notify("refreshing lualine")
     lualine.refresh()
   end
 

--- a/lua/jellybeans/init.lua
+++ b/lua/jellybeans/init.lua
@@ -5,10 +5,10 @@ function M.setup(opts)
   require("jellybeans.config").setup(opts)
 end
 
-function M.load()
+function M.load(palette_name_override)
   local ok, result = pcall(function()
     local config = require("jellybeans.config")
-    return require("jellybeans.highlights").setup(config.opts)
+    return require("jellybeans.highlights").setup(config.opts, palette_name_override)
   end)
 
   if not ok then

--- a/lua/jellybeans/init.lua
+++ b/lua/jellybeans/init.lua
@@ -1,36 +1,15 @@
 local M = {}
 
-local is_loading = false
-
 ---@param opts? jellybeans.Config
 function M.setup(opts)
   require("jellybeans.config").setup(opts)
-
-  vim.api.nvim_create_autocmd("OptionSet", {
-    group = vim.api.nvim_create_augroup("JellybeansColorscheme", { clear = true }),
-    pattern = "background",
-    callback = function()
-      local config = require("jellybeans.config")
-      local b = vim.o.background
-      config.opts.style = b == "light" and "light" or "dark"
-      M.load()
-    end,
-  })
 end
 
----@param load_opts? {palette?: string}
-function M.load(load_opts)
-  if is_loading then
-    return
-  end
-
-  is_loading = true
+function M.load()
   local ok, result = pcall(function()
     local config = require("jellybeans.config")
-    local opts = vim.tbl_deep_extend("force", config.opts, load_opts or {})
-    return require("jellybeans.highlights").setup(opts)
+    return require("jellybeans.highlights").setup(config.opts)
   end)
-  is_loading = false
 
   if not ok then
     vim.notify("Failed to load jellybeans colorscheme: " .. tostring(result), vim.log.levels.ERROR)
@@ -38,18 +17,6 @@ function M.load(load_opts)
   end
 
   return result
-end
-
-function M.toggle()
-  local config = require("jellybeans.config")
-  config.opts.style = config.opts.style == "light" and "dark" or "light"
-  vim.o.background = config.opts.style
-  M.load()
-
-  local has_lualine, lualine = pcall(require, "lualine")
-  if has_lualine then
-    lualine.refresh()
-  end
 end
 
 return M

--- a/lua/jellybeans/init.lua
+++ b/lua/jellybeans/init.lua
@@ -16,6 +16,7 @@ function M.load()
     return
   end
 
+  vim.g.colors_name = "jellybeans"
   return result
 end
 

--- a/lua/jellybeans/palettes/init.lua
+++ b/lua/jellybeans/palettes/init.lua
@@ -1,27 +1,18 @@
 local M = {}
 
 ---@class ColorScheme: Palette
-function M.get_palette(palette, opts)
-  -- Set palette to "jellybeans" (default) or the specified palette
-  local type_palette = palette or "jellybeans"
-
-  -- Add "_light" suffix for light style
-  if opts.style == "light" then
-    type_palette = type_palette .. "_light"
-  end
-
-  -- Try to load the specified palette
-  local ok, colors = pcall(require, "jellybeans.palettes." .. type_palette)
+function M.get_palette(palette_name, opts)
+  local ok, p = pcall(require, "jellybeans.palettes." .. palette_name)
   if not ok then
-    vim.notify("Failed to load palette: " .. type_palette, vim.log.levels.ERROR)
-    -- Fall back to default jellybeans palette
+    vim.notify("Failed to load palette: " .. palette_name, vim.log.levels.ERROR)
     return require("jellybeans.palettes.jellybeans")
   end
 
   if opts.on_colors then
-    opts.on_colors(colors)
+    opts.on_colors(p.colors)
   end
-  return colors
+
+  return p
 end
 
 return M

--- a/lua/jellybeans/palettes/init.lua
+++ b/lua/jellybeans/palettes/init.lua
@@ -9,7 +9,7 @@ function M.get_palette(palette_name, opts)
   end
 
   if opts.on_colors then
-    opts.on_colors(p.colors)
+    opts.on_colors(p.palette)
   end
 
   return p

--- a/lua/jellybeans/palettes/jellybeans.lua
+++ b/lua/jellybeans/palettes/jellybeans.lua
@@ -89,4 +89,8 @@ palette.none = "NONE"
 palette.float_bg = palette.gravel
 palette.float_border = palette.tundora
 
-return palette
+return {
+  name = "jellybeans",
+  style = "dark",
+  palette = palette,
+}

--- a/lua/jellybeans/palettes/jellybeans_light.lua
+++ b/lua/jellybeans/palettes/jellybeans_light.lua
@@ -90,4 +90,8 @@ palette.none = "NONE"
 palette.float_bg = palette.grey_three
 palette.float_border = palette.tundora
 
-return palette
+return {
+  name = "jellybeans_light",
+  style = "light",
+  palette = palette,
+}

--- a/lua/jellybeans/palettes/jellybeans_muted.lua
+++ b/lua/jellybeans/palettes/jellybeans_muted.lua
@@ -88,4 +88,8 @@ palette.none = "NONE"
 palette.float_bg = palette.gravel
 palette.float_border = palette.tundora
 
-return palette
+return {
+  name = "jellybeans_muted",
+  style = "dark",
+  palette = palette,
+}

--- a/lua/jellybeans/palettes/jellybeans_muted_light.lua
+++ b/lua/jellybeans/palettes/jellybeans_muted_light.lua
@@ -89,5 +89,8 @@ palette.none = "NONE"
 palette.float_bg = palette.grey_three
 palette.float_border = palette.tundora
 
-return palette
-
+return {
+  name = "jellybeans_muted_light",
+  style = "light",
+  palette = palette,
+}

--- a/lua/lualine/themes/jellybeans.lua
+++ b/lua/lualine/themes/jellybeans.lua
@@ -2,12 +2,8 @@ local palettes = require("jellybeans.palettes")
 local config = require("jellybeans.config")
 
 local function get_theme()
-  local style = config.opts.style or (vim.o.background == "light" and "light" or "dark")
-  local palette_name = config.opts.palette or "jellybeans"
-  local c = palettes.get_palette(palette_name, { 
-    style = style,
-    on_colors = config.opts.on_colors
-  })
+  local p = palettes.get_palette("jellybeans_muted", config.opts)
+  local c = p.palette
 
   if not c then
     vim.notify("Failed to load jellybeans palette for lualine", vim.log.levels.ERROR)

--- a/lua/lualine/themes/jellybeans.lua
+++ b/lua/lualine/themes/jellybeans.lua
@@ -2,7 +2,9 @@ local palettes = require("jellybeans.palettes")
 local config = require("jellybeans.config")
 
 local function get_theme()
-  local p = palettes.get_palette("jellybeans_muted", config.opts)
+  local bg = vim.o.background
+  local palette_name = config.opts.background[bg]
+  local p = palettes.get_palette(palette_name, config.opts)
   local c = p.palette
 
   if not c then


### PR DESCRIPTION
  ## Summary
  This PR introduces a breaking change to the colorscheme configuration API,
  replacing the deprecated `style` and `palette` options with a new `background`
  configuration system that improves palette management.

  ### Breaking Changes
  - Removes `opts.style` and `opts.palette` in favor of the new `background` option
  - Removes automatic style switching via autocmd
  - Changes the palette loading mechanism to directly reference specific palettes
  - Modifies theme file structure to support the new system

  ### Improvements
  - Adds deprecation warnings for old configuration options
  - Simplifies palette selection based on background setting
  - Correctly registers theme palettes with Neovim
  - Adds default color palette file
  - Improves code organization and typing

  ### Additional Changes
  - Adds comprehensive GitHub issue templates for bug reports, feature requests,
    and theme issues

  ## Migration
  Update your configuration from:
  ```lua
  require('jellybeans').setup({
    style = "dark", -- or "light"
    palette = "jellybeans_muted" -- or other palette
  })

  To:
  require('jellybeans').setup({
    background = {
      dark = "jellybeans_muted", -- palette to use in dark mode
      light = "jellybeans_muted_light" -- palette to use in light mode
    }
  })
