### PR TITLE
feat: Make `opts` optional for greater flexibility in plugin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
   "wtfox/jellybeans.nvim",
   lazy = false,
   priority = 1000,
-  opts = {},
+  opts = {}, -- Optional
 }
 ```
 

--- a/lua/jellybeans/config.lua
+++ b/lua/jellybeans/config.lua
@@ -18,8 +18,8 @@ M.defaults = {
   italics = true,
   flat_ui = true,
   background = {
-    dark = "jellybeans_muted",
-    light = "jellybeans_muted_light",
+    dark = "jellybeans",
+    light = "jellybeans_light",
   },
   plugins = {
     all = false,

--- a/lua/jellybeans/groups/init.lua
+++ b/lua/jellybeans/groups/init.lua
@@ -32,6 +32,9 @@ function M.get(name, colors, opts)
 end
 
 function M.setup(colors, opts)
+  opts = opts or {}
+  opts.plugins = opts.plugins or {}
+
   local groups = {
     editor = true,
     syntax = true,
@@ -86,7 +89,9 @@ function M.setup(colors, opts)
 
   Util.resolve(ret)
 
-  opts.on_highlights(ret, colors)
+  if opts.on_highlights then
+    opts.on_highlights(ret, colors)
+  end
 
   return ret, groups
 end

--- a/lua/jellybeans/groups/treesitter.lua
+++ b/lua/jellybeans/groups/treesitter.lua
@@ -3,6 +3,7 @@ local Util = require("jellybeans.util")
 local M = {}
 
 function M.get(c, opts)
+  opts = opts or {}
   return {
     ["@annotation"] = "PreProc",
     ["@attribute"] = "PreProc",

--- a/lua/jellybeans/init.lua
+++ b/lua/jellybeans/init.lua
@@ -8,7 +8,8 @@ end
 function M.load(palette_name_override)
   local ok, result = pcall(function()
     local config = require("jellybeans.config")
-    return require("jellybeans.highlights").setup(config.opts, palette_name_override)
+    local opts = config.opts or config.defaults
+    return require("jellybeans.highlights").setup(opts, palette_name_override)
   end)
 
   if not ok then

--- a/lua/jellybeans/palettes/init.lua
+++ b/lua/jellybeans/palettes/init.lua
@@ -8,7 +8,7 @@ function M.get_palette(palette_name, opts)
     return require("jellybeans.palettes.jellybeans")
   end
 
-  if opts.on_colors then
+  if opts and opts.on_colors then
     opts.on_colors(p.palette)
   end
 

--- a/lua/lualine/themes/jellybeans.lua
+++ b/lua/lualine/themes/jellybeans.lua
@@ -2,9 +2,10 @@ local palettes = require("jellybeans.palettes")
 local config = require("jellybeans.config")
 
 local function get_theme()
+  local opts = config.opts or config.defaults
   local bg = vim.o.background
-  local palette_name = config.opts.background[bg]
-  local p = palettes.get_palette(palette_name, config.opts)
+  local palette_name = opts.background[bg]
+  local p = palettes.get_palette(palette_name, opts)
   local c = p.palette
 
   if not c then


### PR DESCRIPTION
This change allows the opts property to be optional, enabling simpler plugin configurations such as:

```lua
{
  "WTFox/jellybeans.nvim",
  lazy = false,
  priority = 1000,
  config = function()
    vim.cmd.colorscheme("jellybeans")
  end,
}
```

This makes the plugin easier to use in a variety of contexts, such as cloning it directly into the Neovim plugin directory without requiring additional configuration or package manager.

**Why this PR:**

I'm the author of [vimcolorschemes.com](https://vimcolorschemes.com), and I noticed `jellybeans.nvim` wasn't appearing on the site. That's because the site's preview generator installs colorschemes by cloning them locally, without passing any options, meaning plugins requiring `opts` are skipped.

Making `opts` optional resolves this and allows your colorscheme to be featured on the site. I did it manually for now, here's [the link](https://vimcolorschemes.com/wtfox/jellybeans.nvim).

This is just a suggestion, and I'm happy to adjust or allow you to adjust the PR if you have any feedback or prefer a different approach. Thanks!